### PR TITLE
removing gfrortan deps and python version bump

### DIFF
--- a/Dockerfile-flask
+++ b/Dockerfile-flask
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 COPY /plgrid /usr/local/bin/plgrid
 WORKDIR /usr/local/app
 

--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -1,11 +1,6 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 ARG SHIELDHIT_PATH
 COPY $SHIELDHIT_PATH /usr/local/bin/shieldhit
-
-# gfortran is needed by shieldhit binary to execute properly
-RUN apt-get -qq update && \
-    apt-get install -qq -y --no-install-recommends gfortran && \
-    rm -rf /var/lib/apt/lists/*
 
 # install dependencies
 WORKDIR /usr/local/app


### PR DESCRIPTION
This PR removed installation of `gfortran` libraries needed by shieldhit binary compiled with `make -j`. Now we switch to a version which is fully statically compiled, see https://github.com/yaptide/yaptide/issues/233#issue-1449420398