### PR TITLE
limit CPU resources for flask worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,10 @@ services:
                 SHIELDHIT_PATH: ${SHIELDHIT_PATH-/shieldhit}
             dockerfile: Dockerfile-worker
         image: yaptide_worker
+        deploy:
+            resources:
+                limits:
+                    cpus: ${MAX_CORES-/1}
         container_name: yaptide_worker
         command: celery --app yaptide.celery.worker worker -P threads --loglevel=info
         environment:


### PR DESCRIPTION
Up to 2 cores will be left for flask.
This way we partially avoid situation where MC simulation will make flask unresponsive.

To be tested with https://github.com/yaptide/deploy/pull/21