### PR TITLE
bump converter

### DIFF
--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -2,6 +2,11 @@ FROM python:3.10-slim
 ARG SHIELDHIT_PATH
 COPY $SHIELDHIT_PATH /usr/local/bin/shieldhit
 
+# gfortran is needed by shieldhit binary to execute properly
+RUN apt-get -qq update && \
+    apt-get install -qq -y --no-install-recommends gfortran && \
+    rm -rf /var/lib/apt/lists/*
+
 # install dependencies
 WORKDIR /usr/local/app
 COPY ./requirements.txt ./


### PR DESCRIPTION
By adding back gfortran to the worker Dockerfile we should be able to run all versions of SH12A
also converter by