### PR TITLE
Enable auto-merge for Dependabot PRs being patches

### DIFF
--- a/.github/workflows/deps-pr-automation.yml
+++ b/.github/workflows/deps-pr-automation.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs being patches
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Right now to merge dependabot PRs we need to do following steps:

- mark the PR as "Ready to be merged"
- test manually the PR
- give it approve

After this PR first step won't be necessary, following workflow should work:

- test manually the PR
- give it approve