### PR TITLE
run coverage report only on master

### DIFF
--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -48,6 +48,7 @@ jobs:
   report-test-converage-deepsource:
     needs: build-and-test
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Runs coverage report only on master branch, to avoid errors when deepsource has no access to repo secrets