### PR TITLE
https support

### DIFF
--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -1,5 +1,28 @@
+# Stage 1: Generate SSL certificate
+FROM alpine AS cert-gen
+
+RUN apk add --no-cache openssl
+
+WORKDIR /certs
+
+RUN openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 \
+    -subj "/C=US/ST=State/L=City/O=Organization/CN=localhost" \
+    -keyout server.key -out server.crt
+
+
+# Stage 2: Serve the nginx proxy
 FROM nginx:1.25-alpine
 
-# Configure Nginx to serve as the proxy for the Flask app
+# Configure Nginx to serve as the proxy
 RUN rm /etc/nginx/conf.d/default.conf
+
+
+# Copy SSL certificate from the build stage
+COPY --from=cert-gen /certs /etc/nginx/conf.d
+
+# Copy the Nginx configuration
 COPY nginx.conf /etc/nginx/conf.d
+
+EXPOSE 5000
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -37,20 +37,9 @@ git submodule update --init --recursive
 
 You can build and run the app using the following command:
 
-Linux:
-
 ```shell
-SHIELDHIT_PATH=path/to/shieldhit docker compose up -d --build
-```
-
-Windows Powershell:
-
-```shell
-$env:SHIELDHIT_PATH = "path.to.shieldhit"
 docker compose up -d --build
 ```
-
-Due to docker specific limitations, shieldhit path cannot be absolute path. shieldhit binary needs to be located in the same or in one of yaptide subdirectories (at the same or lower level than Dockerfile).
 
 Once it's running, the app will be available at [http://localhost:5000](http://localhost:5000). If you get an error saying the container name is already in use, stop and remove the container and then try again.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
             dockerfile: Dockerfile-nginx
         ports:
             - 5000:5000
+            - 8443:8443
         depends_on:
             - yaptide_flask
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -6,7 +6,10 @@ upstream backend_flask {
 # main server listening on port 5000
 server {
 
-    listen 5000;
+    listen 5000 ssl;
+
+    ssl_certificate /etc/nginx/conf.d/server.crt;
+    ssl_certificate_key /etc/nginx/conf.d/server.key;
 
     # set CORS policy for all requests including preflighted ones (credentials are allowed by default)
     location / {

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,10 +3,11 @@ upstream backend_flask {
     server yaptide_flask:6000;
 }
 
-# main server listening on port 5000
+# main proxy server listening on port 5000 for plain HTTP and 8443 for HTTPS
 server {
 
-    listen 5000 ssl;
+    listen 5000;
+    listen 8443 ssl;
 
     ssl_certificate /etc/nginx/conf.d/server.crt;
     ssl_certificate_key /etc/nginx/conf.d/server.key;


### PR DESCRIPTION
This PR introduces HTTPS support for backend. There is not much change for a local deploy which still uses HTTP transport.
Production deploy script is adjusted here: https://github.com/yaptide/deploy/pull/33