### PR TITLE
missing method added, increased limit for payload

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -18,10 +18,12 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         add_header 'Access-Control-Allow-Origin' '$http_origin' always;
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, DELETE' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, OPTIONS, DELETE' always;
         add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization' always;
         add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
         add_header 'Access-Control-Allow-Credentials' 'true' always;
+
+        client_max_body_size 100M;
     }
 
 }


### PR DESCRIPTION
This seems to solve the problem of nginx proxy not passing requests with payload larger than 1 MB.
This was tested on yap-dev deployment