### PR TITLE
plgrid-specific access to SHIELD-HIT12A binary

### DIFF
--- a/yaptide/batch/string_templates.py
+++ b/yaptide/batch/string_templates.py
@@ -1,34 +1,12 @@
 SUBMIT_SHIELDHIT: str = """#!/bin/bash
 OUT=`mktemp`
-export PATH="$PATH:$PLG_GROUPS_STORAGE/plggccbmc"
-module load gcc/11.3.0
+module load shieldhit
 
 ROOT_DIR={root_dir}
-BIN_DIR=$ROOT_DIR/bin
 cd $ROOT_DIR
 mkdir -p $ROOT_DIR/workspaces/task_{{0001..{n_tasks}}}
 mkdir -p $ROOT_DIR/input
 
-CONVERTMC_VERSION={convertmc_version}
-
-if [[ -f ${{BIN_DIR}}/convertmc ]]; then
-    FOUND_VERSION=$($BIN_DIR/convertmc --version)
-    if [ $FOUND_VERSION != $CONVERTMC_VERSION ]; then
-        echo "Found old version of convertmc: $FOUND_VERSION"
-        rm $BIN_DIR/convertmc
-        wget -c -x -O $BIN_DIR/convertmc\\
-            https://github.com/DataMedSci/pymchelper/releases/download/v$CONVERTMC_VERSION/convertmc
-        chmod 750 $BIN_DIR/convertmc
-    fi
-else
-    mkdir $BIN_DIR -p
-
-    wget -c -x -O $BIN_DIR/convertmc\\
-        https://github.com/DataMedSci/pymchelper/releases/download/v$CONVERTMC_VERSION/convertmc
-
-    chmod 750 $BIN_DIR/convertmc
-fi
-echo "Using convertmc version: $CONVERTMC_VERSION"
 
 INPUT_DIR=$ROOT_DIR/input
 ARRAY_SCRIPT=$ROOT_DIR/array_script.sh
@@ -55,13 +33,12 @@ COLLECT_BASH: str = """#!/bin/bash
 ROOT_DIR={root_dir}
 INPUT_WILDCARD=$ROOT_DIR/workspaces/task_*/*.bdo
 OUTPUT_DIRECTORY=$ROOT_DIR/output
-BIN_DIR=$ROOT_DIR/bin
 
 mkdir -p $OUTPUT_DIRECTORY
 
 cd $OUTPUT_DIRECTORY
 
-$BIN_DIR/convertmc json --many "$INPUT_WILDCARD"
+convertmc json --many "$INPUT_WILDCARD"
 
 CLEAR_BDOS={clear_bdos}
 


### PR DESCRIPTION
Seems to work as right now SHIELD-HIT12A is available in the module system on Ares.
I tested it on yap-dev and was able to receive simulation output from Ares