### PR TITLE
better check of yaptide access

### DIFF
--- a/yaptide/routes/keycloak_routes.py
+++ b/yaptide/routes/keycloak_routes.py
@@ -32,7 +32,7 @@ def check_user_based_on_keycloak_token(token: str, username: str) -> bool:
         # first lets try to decode token without verifying signature
         unverified_encoded_token = jwt.decode(token, options={"verify_signature": False})
         # check if token gives access to our service
-        if "PLG_YAPTIDE_ACCESS" not in unverified_encoded_token.get("plgridAccessServices"):
+        if "PLG_YAPTIDE_ACCESS" not in unverified_encoded_token.get("plgridAccessServices", []):
             logging.error("User %s has no access to Yaptide service", username)
             raise Forbidden(description=f"User {username} has no access to our service")
 

--- a/yaptide/routes/keycloak_routes.py
+++ b/yaptide/routes/keycloak_routes.py
@@ -32,8 +32,8 @@ def check_user_based_on_keycloak_token(token: str, username: str) -> bool:
         # first lets try to decode token without verifying signature
         unverified_encoded_token = jwt.decode(token, options={"verify_signature": False})
         # check if token gives access to our service
-        if unverified_encoded_token.get("plgridAccessServices") != "PLG_YAPTIDE_ACCESS":
-            logging.error("User %s has no access to our service", username)
+        if "PLG_YAPTIDE_ACCESS" not in unverified_encoded_token.get("plgridAccessServices"):
+            logging.error("User %s has no access to Yaptide service", username)
             raise Forbidden(description=f"User {username} has no access to our service")
 
         # ask keycloak for public keys


### PR DESCRIPTION
During deployment of the yaptide service in plgrid we realised that the allowed services come as list, not as a single value. This PR improves allowed services check