### PR TITLE
Add retention policies for ghcr.io containers

### DIFF
--- a/.github/workflows/cleanup-closed-pr-packages.yaml
+++ b/.github/workflows/cleanup-closed-pr-packages.yaml
@@ -1,0 +1,24 @@
+name: Cleanup packages on closed pull request
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup-packages:
+    name: Cleanup closed PR packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup flask and worker packages
+        uses: snok/container-retention-policy@v2
+        with:
+          image-names: ${{ github.event.repository.name }}-flask, ${{ github.event.repository.name }}-worker
+          cut-off: now UTC
+          timestamp-to-use: created_at
+          account-type: org
+          org-name: ${{ github.repository_owner }}
+          keep-at-least: 0
+          filter-tags: pr-${{github.event.pull_request.number}}
+          token: ${{ secrets.PAT }}
+          dry-run: true

--- a/.github/workflows/cleanup-closed-pr-packages.yaml
+++ b/.github/workflows/cleanup-closed-pr-packages.yaml
@@ -1,4 +1,4 @@
-name: Cleanup packages on closed pull request
+name: Cleanup GHCR docker packages on closed pull request
 
 on:
   pull_request:

--- a/.github/workflows/deploy-master.yaml
+++ b/.github/workflows/deploy-master.yaml
@@ -1,0 +1,92 @@
+name: Deploy worker and flask on push to master
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  REGISTRY: ghcr.io
+  WORKER_IMAGE_NAME: ${{ github.repository }}-worker
+  FLASK_IMAGE_NAME: ${{ github.repository }}-flask
+
+jobs:
+  deploy-worker:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.WORKER_IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          provenance: false
+          context: .
+          push: true
+          file: Dockerfile-worker
+          tags: ${{ steps.meta.outputs.tags }}, ${{ steps.meta.outputs.tags }}-${{github.run_number}}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILDKIT_CONTEXT_KEEP_GIT_DIR=true
+
+  deploy-flask:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.FLASK_IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          provenance: false
+          context: .
+          push: true
+          file: Dockerfile-flask
+          tags: ${{ steps.meta.outputs.tags }}, ${{ steps.meta.outputs.tags }}-${{github.run_number}}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILDKIT_CONTEXT_KEEP_GIT_DIR=true

--- a/.github/workflows/deploy-master.yaml
+++ b/.github/workflows/deploy-master.yaml
@@ -1,4 +1,4 @@
-name: Deploy worker and flask on push to master
+name: Deploy worker and flask docker images to GHCR registry on push to master
 
 on:
   push:

--- a/.github/workflows/manual-deploy-flask.yml
+++ b/.github/workflows/manual-deploy-flask.yml
@@ -55,11 +55,15 @@ jobs:
         uses: docker/metadata-action@v5.4.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Need to override the tag with pr-{issue_number} to make the retention working properly
+          tags: |
+            type=raw,value=pr-${{ github.event.issue.number }}
 
       # see https://github.com/docker/build-push-action/issues/513#issuecomment-987951050
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
+          provenance: false
           context: .
           push: true
           file: Dockerfile-flask

--- a/.github/workflows/manual-deploy-worker.yml
+++ b/.github/workflows/manual-deploy-worker.yml
@@ -55,11 +55,15 @@ jobs:
         uses: docker/metadata-action@v5.4.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Need to override the tag with pr-{issue_number} to make the retention working properly
+          tags: |
+            type=raw,value=pr-${{ github.event.issue.number }}
 
       # see https://github.com/docker/build-push-action/issues/513#issuecomment-987951050
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
+          provenance: false
           context: .
           file: Dockerfile-worker
           push: true

--- a/.github/workflows/packages-retention.yaml
+++ b/.github/workflows/packages-retention.yaml
@@ -1,13 +1,13 @@
-name: Retention policy for worker and flask packages
+name: Retention policy for worker and flask GHCR docker packages
 
 on:
   schedule:
-    - cron: '30 4 * * MON'
+    - cron: '30 4 * * MON' # Running every Monday at 04:30 AM
   workflow_dispatch:
 
 jobs:
   cleanup-packages:
-    name: Cleanup old packages
+    name: Cleanup old GHCR docker packages
     runs-on: ubuntu-latest
     steps:
       - name: Cleanup flask and worker old PR packages

--- a/.github/workflows/packages-retention.yaml
+++ b/.github/workflows/packages-retention.yaml
@@ -1,0 +1,38 @@
+name: Retention policy for worker and flask packages
+
+on:
+  schedule:
+    - cron: '30 4 * * MON'
+  workflow_dispatch:
+
+jobs:
+  cleanup-packages:
+    name: Cleanup old packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup flask and worker old PR packages
+        uses: snok/container-retention-policy@v2
+        with:
+          image-names: ${{ github.event.repository.name }}-flask, ${{ github.event.repository.name }}-worker
+          cut-off: 2 weeks ago UTC
+          timestamp-to-use: created_at
+          account-type: org
+          org-name: ${{ github.repository_owner }}
+          keep-at-least: 0
+          untagged-only: true
+          token: ${{ secrets.PAT }}
+          dry-run: true
+      - name: Cleanup flask and worker old master packages
+        uses: snok/container-retention-policy@v2
+        with:
+          image-names: ${{ github.event.repository.name }}-flask, ${{ github.event.repository.name }}-worker
+          cut-off: 1 month ago UTC
+          timestamp-to-use: created_at
+          account-type: org
+          org-name: ${{ github.repository_owner }}
+          keep-at-least: 0
+          filter-include-untagged: false
+          filter-tags: master-*
+          skip-tags: master # Don't remove the newest master image
+          token: ${{ secrets.PAT }}
+          dry-run: true

--- a/docs/ghcr_packages.md
+++ b/docs/ghcr_packages.md
@@ -1,0 +1,30 @@
+# GHCR Packages
+
+## Deployment
+
+To build a flask or worker docker image and deploy it to the ghcr.io registry in pull requests, the user should write a comment `/deploy-flask` or `/deploy-worker` depending on the image needed. Packages are also automatically built and deployed when the PR is merged to master.
+
+## Usage
+
+All available packages are shown in the [Packages](https://github.com/orgs/yaptide/packages) section of the yaptide organisation in GitHub. Newest master branch image is available with tag `master`. For pull requests it is a PR number prefixed with `pr-`, e.g. `pr-17`. Corresponding docker pull command can be read after clicking on the package. For this case it would be:
+```bash
+docker pull ghcr.io/yaptide/yaptide-flask:pr-17
+```
+
+Deployed packages can be used in various ways. They can be accessed from gitpod.io or GitHub Codespaces to easily run and test them in pull requests. It is also possible to pull the images locally. It is required to log in to ghcr.io via Docker using GitHub credentials:
+```bash
+docker login ghcr.io --username <github_username>
+```
+Then it is allowed to pull the images.
+
+## Retention policies
+
+Both flask and worker images are automatically cleaned up in the registry based on the retention policies:
+
+- Pull request's newest packages are removed when it is merged or closed.
+- Outdated pull requests' packages are removed if they are older than 2 weeks.
+- Outdated master's packages are removed if they are older than 1 month.
+
+It is also possible to run the latter two policies manually by dispatching the `packages-retention` GitHub action. Normally it is dispatched using cron job every Monday at 04:30 AM.
+
+To delete the packages from ghcr.io registry, it is required to use the PAT token created by organisation and repository admin with `read:packages` and `delete:packages` permissions. It should be placed in the organisation's secrets. It is not possible to use other kind of tokens, e.g. action scoped `GITHUB_TOKEN` or fine-grained token.

--- a/docs/ghcr_packages.md
+++ b/docs/ghcr_packages.md
@@ -1,8 +1,15 @@
-# GHCR Packages
+# Docker images on GHCR
+
+GitHub Container Registry is an organisation-scoped place where Docker containers can be stored and then pulled from freely in GitHub Actions and solutions like gitpod.io or GitHub Codespaces. Yaptide's packages are private and can be accessed only by the organisation members.
 
 ## Deployment
 
-To build a flask or worker docker image and deploy it to the ghcr.io registry in pull requests, the user should write a comment `/deploy-flask` or `/deploy-worker` depending on the image needed. Packages are also automatically built and deployed when the PR is merged to master.
+Docker images for backend (Flask) and worker can be automatically built and deployed to ghcr.io registry. Building and deployment are handled by GitHub Actions. There are two methods:
+
+- automatic action triggered after every commit to the master,
+- on-demand action triggered by `/deploy-flask` or `/deploy-worker` comment, typed by user in the Pull Request discussion.
+
+Images from master provide a way to quickly deploy stable version of backend part of the yaptide platform. Images from pull request allows for fast way of testing new features proposed in the PR.
 
 ## Usage
 
@@ -11,7 +18,7 @@ All available packages are shown in the [Packages](https://github.com/orgs/yapti
 docker pull ghcr.io/yaptide/yaptide-flask:pr-17
 ```
 
-Deployed packages can be used in various ways. They can be accessed from gitpod.io or GitHub Codespaces to easily run and test them in pull requests. It is also possible to pull the images locally. It is required to log in to ghcr.io via Docker using GitHub credentials:
+Deployed packages can be accessed from gitpod.io or GitHub Codespaces to easily run and test them in pull requests or on master branch. It might be requested to log in to ghcr.io via Docker using GitHub credentials:
 ```bash
 docker login ghcr.io --username <github_username>
 ```
@@ -19,11 +26,11 @@ Then it is allowed to pull the images.
 
 ## Retention policies
 
-Both flask and worker images are automatically cleaned up in the registry based on the retention policies:
+GitHub Container Registry doesn't provide any retention mechanisms. It is required to use external solutions and define own GitHub Actions for this purpose. Both flask and worker images are automatically cleaned up in the registry based on the custom retention policies defined in `cleanup-closed-pr-packages` and `packages-retention` actions:
 
+- Outdated master's packages are removed if they are older than 1 month.
 - Pull request's newest packages are removed when it is merged or closed.
 - Outdated pull requests' packages are removed if they are older than 2 weeks.
-- Outdated master's packages are removed if they are older than 1 month.
 
 It is also possible to run the latter two policies manually by dispatching the `packages-retention` GitHub action. Normally it is dispatched using cron job every Monday at 04:30 AM.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,7 @@ nav:
   - Jobs and tasks: states.md
   - Simulator binaries: simulator_binaries.md
   - Persistent storage: persistency.md
-  - GHCR packages: ghcr_packages.md
+  - Docker images on GHCR: ghcr_packages.md
 - API Reference: swagger.md
 - Code Reference: reference/
 - Test coverage: coverage.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
   - Jobs and tasks: states.md
   - Simulator binaries: simulator_binaries.md
   - Persistent storage: persistency.md
+  - GHCR packages: ghcr_packages.md
 - API Reference: swagger.md
 - Code Reference: reference/
 - Test coverage: coverage.md


### PR DESCRIPTION
**All cleanup actions have `dry-run` flag set to true, which should be removed before merging.**

### What is required to make the retention working:
- [x] Create PAT token by organisation and repository admin with `read:packages` and `delete:packages` permissions and place it in the organisation's secrets. It is not possible to use other kind of tokens, e.g. action scoped `GITHUB_TOKEN` or fine-grained token.
- [X] Make sure to set `provenance` flag to false in `docker/build-push-action` steps. It is required because of ghcr.io bug and no implemented workaround in `snok/container-retention-policy` action.
- [X] Tag properly the packages deployed in `manual-deploy` actions. Previously it used invalid `master` tag for these images. Now it tags them like `pr-1` for PR 1, `pr-2` for PR 2 etc. It also allows to easily switch to auto deploy (using `on: pull_request` event) in the future.

### Introducing three new actions:
- Cleanup packages on closed pull request in `cleanup-closed-pr-packages.yaml` is run on closed PR event and removes its tagged packages for both flask and worker images.
- Deploy worker and flask on push to master in `deploy-master.yaml` automatically deploys packages on push to master branch event. The build stages are similar to these in `manual-deploy` actions. It also additionally tags the images with `master-1`, `master-2` etc. tags to filter them in retention action below.
- Retention policy for worker and flask packages in `packages-retention.yaml` is the main retention mechanism. It removes all outdated PR packages (untagged) older than 2 weeks. It also removes all outdated master packages (uses tags described above) older than 1 month. This action is a cron job running every Monday at 04:30 AM. If it is not necessary to run it this frequent, these jobs can be put at the end of all deploy actions. It is also possible to run this action manually.

### Limitations:
- Unfortunately it is not possible to make "keep only last 3 'master' images and remove all older than 1 month" policy described in the linked issue. `keep-at-least` field doesn't work well with any tags filtering options. Currently the `keep-at-least` field is set to 0 in this action, so it leaves intact all packages newer than 1 month and the newest `master` package.
- Cleanup on PR closed action could be replaced to only untagging the PR package to allow it to be removed by `packages-retention` action. Currently it can remove the newest PR package, while older one waits to be removed by `packages-retention`.