### PR TITLE
Enable ghcr.io containers retention policies

### DIFF
--- a/.github/workflows/cleanup-closed-pr-packages.yaml
+++ b/.github/workflows/cleanup-closed-pr-packages.yaml
@@ -21,4 +21,3 @@ jobs:
           keep-at-least: 0
           filter-tags: pr-${{github.event.pull_request.number}}
           token: ${{ secrets.PAT }}
-          dry-run: true

--- a/.github/workflows/packages-retention.yaml
+++ b/.github/workflows/packages-retention.yaml
@@ -21,7 +21,6 @@ jobs:
           keep-at-least: 0
           untagged-only: true
           token: ${{ secrets.PAT }}
-          dry-run: true
       - name: Cleanup flask and worker old master packages
         uses: snok/container-retention-policy@v2
         with:
@@ -35,4 +34,3 @@ jobs:
           filter-tags: master-*
           skip-tags: master # Don't remove the newest master image
           token: ${{ secrets.PAT }}
-          dry-run: true


### PR DESCRIPTION
Remove `dry-run` flags from cleanup jobs