### PR TITLE
Cleanup latest PR packages from GHCR older than 2 months 

### DIFF
--- a/.github/workflows/cleanup-closed-pr-packages.yaml
+++ b/.github/workflows/cleanup-closed-pr-packages.yaml
@@ -1,7 +1,7 @@
 name: Cleanup GHCR docker packages on closed pull request
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 

--- a/.github/workflows/packages-retention.yaml
+++ b/.github/workflows/packages-retention.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Cleanup old GHCR docker packages
     runs-on: ubuntu-latest
     steps:
-      - name: Cleanup flask and worker old PR packages
+      - name: Cleanup flask and worker outdated PR packages
         uses: snok/container-retention-policy@v2
         with:
           image-names: ${{ github.event.repository.name }}-flask, ${{ github.event.repository.name }}-worker
@@ -21,7 +21,19 @@ jobs:
           keep-at-least: 0
           untagged-only: true
           token: ${{ secrets.PAT }}
-      - name: Cleanup flask and worker old master packages
+      - name: Cleanup flask and worker latest but old PR packages
+        uses: snok/container-retention-policy@v2
+        with:
+          image-names: ${{ github.event.repository.name }}-flask, ${{ github.event.repository.name }}-worker
+          cut-off: 2 months ago UTC
+          timestamp-to-use: created_at
+          account-type: org
+          org-name: ${{ github.repository_owner }}
+          keep-at-least: 0
+          filter-include-untagged: false
+          filter-tags: pr-*
+          token: ${{ secrets.PAT }}
+      - name: Cleanup flask and worker outdated master packages
         uses: snok/container-retention-policy@v2
         with:
           image-names: ${{ github.event.repository.name }}-flask, ${{ github.event.repository.name }}-worker

--- a/docs/ghcr_packages.md
+++ b/docs/ghcr_packages.md
@@ -31,6 +31,7 @@ GitHub Container Registry doesn't provide any retention mechanisms. It is requir
 - Outdated master's packages are removed if they are older than 1 month.
 - Pull request's newest packages are removed when it is merged or closed.
 - Outdated pull requests' packages are removed if they are older than 2 weeks.
+- Latest pull requests' packages are removed if they are older than 2 months.
 
 It is also possible to run the latter two policies manually by dispatching the `packages-retention` GitHub action. Normally it is dispatched using cron job every Monday at 04:30 AM.
 


### PR DESCRIPTION
Trying to fix the #803 issue. Adding the new policy to cleanup latest PR packages older than 2 months and also trying `pull_request_target` trigger in `cleanup-closed-pr-packages` action to check if it will fix the action not always triggering.