### PR TITLE
Bump eventlet to fix issues with connection to redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,23 @@
 # yaptide backend
 
-## Installation
+## Getting the code
 
-Run: `$ pip install -r requirements.txt`
+Clone the repository including submodules:
 
-Download/update sumbmodules:
+```shell
+git clone --recurse-submodules https://github.com/yaptide/yaptide.git
+```
+
+In case you have used regular `git clone` command, without `--recurse-submodules` option, you can still download the submodules by running:
 
 ```shell
 git submodule update --init --recursive
 ```
+
+## Installation
+
+Run: `pip install -r requirements.txt`
+
 
 ## Running the app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.4"
 services:
 
     redis:
-        image: redis:6-alpine
+        image: redis:7-alpine
         container_name: yaptide_redis
         healthcheck:
             test: ["CMD", "redis-cli", "ping"]
@@ -33,8 +33,8 @@ services:
         container_name: yaptide_flask
         environment:
             - FLASK_DEBUG=1
-            - CELERY_BROKER_URL=redis://redis:6379/0
-            - CELERY_RESULT_BACKEND=redis://redis:6379/0
+            - CELERY_BROKER_URL=redis://yaptide_redis:6379/0
+            - CELERY_RESULT_BACKEND=redis://yaptide_redis:6379/0
             - CERT_AUTH_URL=${CERT_AUTH_URL:-}
             - KEYCLOAK_BASE_URL=${KEYCLOAK_BASE_URL:-}
             - KEYCLOAK_REALM=${KEYCLOAK_REALM:-}
@@ -61,8 +61,8 @@ services:
                     cpus: ${MAX_CORES-1.0}
         env_file: .env
         environment:
-            - CELERY_BROKER_URL=redis://redis:6379/0
-            - CELERY_RESULT_BACKEND=redis://redis:6379/0
+            - CELERY_BROKER_URL=redis://yaptide_redis:6379/0
+            - CELERY_RESULT_BACKEND=redis://yaptide_redis:6379/0
             - BACKEND_INTERNAL_URL=http://yaptide_flask:6000
             - LOG_LEVEL_ROOT=${LOG_LEVEL_ROOT:-INFO}
         depends_on:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ celery==5.3.6
 click==8.1.7
 decorator==5.1.1
 environs==10.3.0
-eventlet==0.35.0
+eventlet==0.35.2
 fabric==3.2.2
 flask-restful==0.3.10
 flask-sqlalchemy==3.1.1
@@ -10,7 +10,7 @@ flask_swagger_ui==4.11.1
 flask==2.3.3
 pyjwt==2.8.0
 pymchelper==2.6.4
-redis==5.0.1
+redis==5.0.2
 requests==2.31.0
 scipy==1.12.0  # needed by converter submodule
 SQLAlchemy==2.0.25

--- a/run_worker.sh
+++ b/run_worker.sh
@@ -29,4 +29,4 @@ else
     ./yaptide/admin/simulators.py download-fluka --dir /simulators
 fi
 
-celery --app yaptide.celery.worker worker -E --loglevel="$LOG_LEVEL_ROOT" -P eventlet --hostname yaptide-worker
+celery --app yaptide.celery.worker worker --events --loglevel="$LOG_LEVEL_ROOT" --pool eventlet --hostname yaptide-worker


### PR DESCRIPTION
I suspected the issues with connection to redis were caused by the way celery is using its redis connector. I've connected to the `yaptide_worker` image and played with simple celery apps which experienced no issues in connecting to redis.
Then I ran simply `celery --app yaptide.celery.worker worker` and discovered no issue.
Then subsequently I was adding more switches. I've realized that the problem appeared on adding `--pool eventlet`. I've inspected on what version `eventlet` library is. Instinctively I've tried updating to the newest one 0.35.2 and this seemed to fix the problem.

Strangle I don't see any development in 0.35.1 and 0.35.2 that seems to be related to our issues:

https://github.com/eventlet/eventlet/blob/v0.35.2/NEWS#L4-L18