### PR TITLE
improve docker compose health checks

### DIFF
--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -48,8 +48,5 @@ RUN python3 -c "import os; content = open('yaptide/admin/simulator_storage.py', 
 # skipcq: DOK-W1001
 RUN chmod +x run_worker.sh yaptide/admin/simulators.py
 
-# Health check
-HEALTHCHECK --start-period=30s CMD celery --app yaptide.celery.worker inspect ping
-
 # Set the script as the entry point, Windows users require to run the script via bash, as `./` does not work
 ENTRYPOINT ["bash", "run_worker.sh"]

--- a/docker-compose.fast.yml
+++ b/docker-compose.fast.yml
@@ -1,4 +1,8 @@
-# this file should give much faster starting time but require docker engine v25 (released 2024-01-19)
+# Enhanced Startup Configuration:
+# Requires Docker Engine v25 (2024-01-19). Modifies healthcheck frequency for improved startup times.
+# Initial healthchecks every 5 seconds for the first 30 seconds post-container launch to mitigate delays from container dependencies.
+# Post-initial period, healthchecks revert to standard 30-second intervals.
+
 
 services:
   redis:

--- a/docker-compose.fast.yml
+++ b/docker-compose.fast.yml
@@ -18,5 +18,5 @@ services:
 
   yaptide_worker:
     healthcheck:
-      start_period: 30s
+      start_period: 60s
       start_interval: 5s

--- a/docker-compose.fast.yml
+++ b/docker-compose.fast.yml
@@ -1,0 +1,22 @@
+# this file should give much faster starting time but require docker engine v25 (released 2024-01-19)
+
+services:
+  redis:
+    healthcheck:
+      start_period: 30s
+      start_interval: 5s
+
+  postgresql:
+    healthcheck:
+      start_period: 30s
+      start_interval: 5s
+
+  yaptide_flask:
+    healthcheck:
+      start_period: 30s
+      start_interval: 5s
+
+  yaptide_worker:
+    healthcheck:
+      start_period: 30s
+      start_interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
       - CELERY_RESULT_BACKEND=redis://yaptide_redis:6379/0
       - BACKEND_INTERNAL_URL=http://yaptide_flask:6000
       - LOG_LEVEL_ROOT=${LOG_LEVEL_ROOT:-INFO}
+    healthcheck:
+      test: ["CMD-SHELL", "celery --app yaptide.celery.worker inspect ping"]
     depends_on:
       redis:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,91 +1,86 @@
-version: "3.4"
-
 services:
+  redis:
+    image: redis:7-alpine
+    container_name: yaptide_redis
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
 
-    redis:
-        image: redis:7-alpine
-        container_name: yaptide_redis
-        healthcheck:
-            test: ["CMD", "redis-cli", "ping"]
+  postgresql:
+    image: postgres:latest
+    container_name: yaptide_postgresql
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-yaptide_db}
+      POSTGRES_USER: ${POSTGRES_USER:-yaptide_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-yaptide_password}
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - data:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h $${POSTGRES_HOST:-postgresql} -p $${POSTGRES_PORT:-5432} -U $${POSTGRES_USER:-yaptide_user}"]
 
-    postgresql:
-        image: postgres:latest
-        container_name: yaptide_postgresql
-        environment:
-            POSTGRES_DB: ${POSTGRES_DB:-yaptide_db}
-            POSTGRES_USER: ${POSTGRES_USER:-yaptide_user}
-            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-yaptide_password}
-            PGDATA: /var/lib/postgresql/data/pgdata
-        volumes:
-            - data:/var/lib/postgresql/data
-        ports:
-            - 5432:5432
-        healthcheck:
-            test: ["CMD-SHELL", "pg_isready -h $${POSTGRES_HOST:-postgresql} -p $${POSTGRES_PORT:-5432} -U $${POSTGRES_USER:-yaptide_user}"]
-            # start_period: 30s
-            # retries: 5
+  yaptide_flask:
+    build:
+      context: .
+      dockerfile: Dockerfile-flask
+    image: yaptide_flask
+    container_name: yaptide_flask
+    environment:
+      - FLASK_DEBUG=1
+      - CELERY_BROKER_URL=redis://yaptide_redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://yaptide_redis:6379/0
+      - CERT_AUTH_URL=${CERT_AUTH_URL:-}
+      - KEYCLOAK_BASE_URL=${KEYCLOAK_BASE_URL:-}
+      - KEYCLOAK_REALM=${KEYCLOAK_REALM:-}
+      - BACKEND_EXTERNAL_URL=${BACKEND_EXTERNAL_URL:-}
+      - FLASK_SQLALCHEMY_DATABASE_URI=postgresql+psycopg://${POSTGRES_USER:-yaptide_user}:${POSTGRES_PASSWORD:-yaptide_password}@postgresql:5432/${POSTGRES_DB:-yaptide_db}
+    depends_on:
+      redis:
+        condition: service_healthy
+      postgresql:
+        condition: service_healthy
 
-    yaptide_flask:
-        build:
-            context: .
-            dockerfile: Dockerfile-flask
-        image: yaptide_flask
-        container_name: yaptide_flask
-        environment:
-            - FLASK_DEBUG=1
-            - CELERY_BROKER_URL=redis://yaptide_redis:6379/0
-            - CELERY_RESULT_BACKEND=redis://yaptide_redis:6379/0
-            - CERT_AUTH_URL=${CERT_AUTH_URL:-}
-            - KEYCLOAK_BASE_URL=${KEYCLOAK_BASE_URL:-}
-            - KEYCLOAK_REALM=${KEYCLOAK_REALM:-}
-            - BACKEND_EXTERNAL_URL=${BACKEND_EXTERNAL_URL:-}
-            - FLASK_SQLALCHEMY_DATABASE_URI=postgresql+psycopg://${POSTGRES_USER:-yaptide_user}:${POSTGRES_PASSWORD:-yaptide_password}@postgresql:5432/${POSTGRES_DB:-yaptide_db}
-        depends_on:
-            redis:
-                condition: service_healthy
-            postgresql:
-                condition: service_healthy
+  yaptide_worker:
+    build:
+      context: .
+      dockerfile: Dockerfile-worker
+    image: yaptide_worker
+    container_name: yaptide_worker
+    volumes:
+      - simulators:/simulators:rw
+    deploy:
+      resources:
+        limits:
+          # the explanation of below syntax: https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html
+          cpus: ${MAX_CORES-1.0}
+    env_file: .env
+    environment:
+      - CELERY_BROKER_URL=redis://yaptide_redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://yaptide_redis:6379/0
+      - BACKEND_INTERNAL_URL=http://yaptide_flask:6000
+      - LOG_LEVEL_ROOT=${LOG_LEVEL_ROOT:-INFO}
+    depends_on:
+      redis:
+        condition: service_healthy
+      yaptide_flask:
+        condition: service_healthy
 
-    yaptide_worker:
-        build:
-            context: .
-            dockerfile: Dockerfile-worker
-        image: yaptide_worker
-        container_name: yaptide_worker
-        volumes:
-            - simulators:/simulators:rw
-        deploy:
-            resources:
-                limits:
-                    # the explanation of below syntax: https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html
-                    cpus: ${MAX_CORES-1.0}
-        env_file: .env
-        environment:
-            - CELERY_BROKER_URL=redis://yaptide_redis:6379/0
-            - CELERY_RESULT_BACKEND=redis://yaptide_redis:6379/0
-            - BACKEND_INTERNAL_URL=http://yaptide_flask:6000
-            - LOG_LEVEL_ROOT=${LOG_LEVEL_ROOT:-INFO}
-        depends_on:
-            redis:
-                condition: service_healthy
-            yaptide_flask:
-                condition: service_healthy
-
-    nginx:
-        image: yaptide_nginx
-        container_name: yaptide_nginx
-        build:
-            context: .
-            dockerfile: Dockerfile-nginx
-        ports:
-            - 5000:5000
-            - 8443:8443
-        depends_on:
-            yaptide_flask:
-                condition: service_healthy
-            yaptide_worker:
-                condition: service_healthy
+  nginx:
+    image: yaptide_nginx
+    container_name: yaptide_nginx
+    build:
+      context: .
+      dockerfile: Dockerfile-nginx
+    ports:
+      - 5000:5000
+      - 8443:8443
+    depends_on:
+      yaptide_flask:
+        condition: service_healthy
+      yaptide_worker:
+        condition: service_healthy
 
 volumes:
-    data:
-    simulators:
+  data:
+  simulators:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# this docker compose should be compatible also with older (<=v24) version of docker engine
+
 services:
   redis:
     image: redis:7-alpine

--- a/docs/using_docker.md
+++ b/docs/using_docker.md
@@ -1,9 +1,15 @@
 # Using Docker
 
-You can build and run the app using the following command:
+You can build and run the app using docker compose. Stop here and read following paragraphs before blindly copy-pasting next command:
 
 ```shell
-docker compose up -d --build
+docker compose up --build --detach
+```
+
+If you have docker engine v25 (released 2024-01-19) or newer the you can profit from fast starting time and use following command:
+
+```shell
+docker compose -f docker-compose.yml -f docker-compose.fast.yml up --build --detach
 ```
 
 Once it's running, the app will be available at [http://localhost:5000](http://localhost:5000). If you get an error saying the container name is already in use, stop and remove the container and then try again.


### PR DESCRIPTION
Time needed to bring up backend with command that works for all docker engines (including v24 and older). The tests were made with S3 variables set so the download time of the SHIELD-HIT12A binaries were short (<10s). Note that withous S3 variables the yaptide_worker needs to download demo version of SHIELD-HIT12A binaries which may take even one minute.

```shell
grzanka@grzankax1:~/workspace/yaptide$ time docker compose up --detach
[+] Running 5/6
 ⠹ Network yaptide_default       Created                                                                                                                                         95.2s 
 ✔ Container yaptide_redis       Healthy                                                                                                                                         30.9s 
 ✔ Container yaptide_postgresql  Healthy                                                                                                                                         31.4s 
 ✔ Container yaptide_flask       Healthy                                                                                                                                         62.2s 
 ✔ Container yaptide_worker      Healthy                                                                                                                                         94.5s 
 ✔ Container yaptide_nginx       Started                                                                                                                                         94.8s 

real	1m35.341s
user	0m0.812s
sys	0m0.355s
```

The same effect when using command which works only on docker enging v25 or newer:

```shell
grzanka@grzankax1:~/workspace/yaptide$ time docker compose -f docker-compose.yml -f docker-compose.fast.yml up --detach 
[+] Running 5/6
 ⠼ Network yaptide_default       Created                                                                                                                                         23.5s 
 ✔ Container yaptide_postgresql  Healthy                                                                                                                                          6.6s 
 ✔ Container yaptide_redis       Healthy                                                                                                                                          6.6s 
 ✔ Container yaptide_flask       Healthy                                                                                                                                         12.3s 
 ✔ Container yaptide_worker      Healthy                                                                                                                                         22.6s 
 ✔ Container yaptide_nginx       Started                                                                                                                                         22.9s 

real	0m23.589s
user	0m0.255s
sys	0m0.083s

```