### PR TITLE
removed pytest-celery; fixed tmp fixture

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1849,20 +1849,6 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
-name = "pytest-celery"
-version = "0.0.0"
-description = "pytest-celery a shim pytest plugin to enable celery.contrib.pytest"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pytest-celery-0.0.0.tar.gz", hash = "sha256:cfd060fc32676afa1e4f51b2938f903f7f75d952186b8c6cf631628c4088f406"},
-    {file = "pytest_celery-0.0.0-py2.py3-none-any.whl", hash = "sha256:63dec132df3a839226ecb003ffdbb0c2cb88dd328550957e979c942766578060"},
-]
-
-[package.dependencies]
-celery = ">=4.4.0"
-
-[[package]]
 name = "pytest-cov"
 version = "5.0.0"
 description = "Pytest plugin for measuring coverage."
@@ -2563,4 +2549,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "58d03d23bdd19e35ae78bad38553bce6f9de56a850b48c0eb4d39378903956fc"
+content-hash = "597460f344da16ea2d3f02b230eae50ddbe0e75fddc629d8d382d073d34bcbf3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ cryptography = "42.0.8"
 psycopg = {version = "3.1.19", extras = ["binary"]}
 
 [tool.poetry.group.test.dependencies]
-pytest-celery = "0.0.0"
 pytest-flask = "1.3.0"
 pytest-cov = "5.0.0"
 pytest-env = "1.1.3"

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,7 +13,6 @@ env =
     FLASK_SQLALCHEMY_DATABASE_URI=sqlite://
     # internal address of the flask app
     BACKEND_INTERNAL_URL=http://127.0.0.1:5000
-    # address of redis server
 # the lines below are for pytest to print the logs in the console
 log_cli = true
 log_cli_level = INFO

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,12 +8,12 @@ env =
     # FLASK_ prefixed variables are used by the flask app factory
     FLASK_TESTING=True
     FLASK_DEBUG=True
-    FLASK_SERVER_NAME=localhost
+    FLASK_SERVER_NAME=127.0.0.1
     # default in-memory database for testing
     FLASK_SQLALCHEMY_DATABASE_URI=sqlite://
     # internal address of the flask app
-    BACKEND_INTERNAL_URL=http://localhost:5000
-
+    BACKEND_INTERNAL_URL=http://127.0.0.1:5000
+    # address of redis server
 # the lines below are for pytest to print the logs in the console
 log_cli = true
 log_cli_level = INFO

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,7 +11,6 @@ from yaptide.admin.simulator_storage import download_shieldhit_from_s3_or_from_w
 from yaptide.application import create_app
 
 
-
 @pytest.fixture(scope='session')
 def small_simulation_payload(payload_editor_dict_data: dict) -> Generator[dict, None, None]:
     """Small simulation payload for testing purposes"""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,9 +8,8 @@ import subprocess
 from typing import Generator
 import pytest
 from yaptide.admin.simulator_storage import download_shieldhit_from_s3_or_from_website
-
 from yaptide.application import create_app
-from yaptide.persistence.database import db
+from celery.contrib.pytest import *
 
 
 @pytest.fixture(scope='session')
@@ -72,14 +71,14 @@ def shieldhit_binary_installed(shieldhit_binary_filename):
 
 
 @pytest.fixture(scope='session')
-def yaptide_bin_dir() -> Generator[Path, None, None]:
+def yaptide_bin_dir():
     """directory with simulators executable files"""
     project_main_dir = Path(__file__).resolve().parent.parent.parent
     yield project_main_dir / 'bin'
 
 
 @pytest.fixture(scope='function')
-def add_simulators_to_path_variable(yaptide_bin_dir: Path):
+def add_simulators_to_path_variable(yaptide_bin_dir):
     """Adds bin directory with simulators executable file to PATH"""
     logging.info("Adding %s to PATH", yaptide_bin_dir)
 
@@ -122,42 +121,6 @@ def add_simulator_mocks_to_path_variable(yaptide_fake_dir: Path):
 
 
 @pytest.fixture(scope='function')
-def celery_app():
-    """
-    Create celery app for testing, we reuse the one from yaptide.celery.worker module.
-    The choice of broker and backend is important, as we don't want to run external redis server.
-    That is being configured via environment variables in pytest.ini file.
-    """
-    logging.info("Creating celery app for testing, time = %s", datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
-    from yaptide.celery.worker import celery_app as app
-    # choose eventlet as a default pool, as it is the only one properly supporting cancellation of tasks
-    app.conf.task_default_pool = 'eventlet'
-    yield app
-
-
-@pytest.fixture(scope="function")
-def celery_worker_parameters() -> Generator[dict, None, None]:
-    """
-    Default celery worker parameters cause problems with finding "ping task" module, as being described here:
-    https://github.com/celery/celery/issues/4851#issuecomment-604073785
-    To solve that issue we disable the ping check.
-    Another solution would be to do `from celery.contrib.testing.tasks import ping` but current one is more elegant.
-
-    Here we could as well configure other fixture worker parameters, like app, pool, loglevel, etc.
-    """
-    logging.info("Creating celery worker parameters for testing")
-
-    # get current logging level
-    log_level = logging.getLogger().getEffectiveLevel()
-
-    yield {
-        "perform_ping_check": False,
-        "concurrency": 2,
-        "loglevel": log_level,  # set celery worker log level to the same as the one used by pytest
-    }
-
-
-@pytest.fixture(scope='function')
 def modify_tmpdir(tmpdir_factory):
     """
     In yaptide some of the modules (pymchelper?) uses temporary directories to store files.
@@ -191,17 +154,17 @@ def modify_tmpdir(tmpdir_factory):
 
     # Restore the original TMPDIR value after the tests are done
     if original_tmpdir is None:
-        del os.environ['TMP']
+        del os.environ['TMPDIR']
     else:
-        os.environ['TMP'] = original_tmpdir
+        os.environ['TMPDIR'] = original_tmpdir
     if original_temp is None:
         del os.environ['TEMP']
     else:
         os.environ['TEMP'] = original_temp
     if original_tmp is None:
-        del os.environ['TMPDIR']
+        del os.environ['TMP']
     else:
-        os.environ['TMPDIR'] = original_tmp
+        os.environ['TMP'] = original_tmp
 
 
 @pytest.fixture(scope="function")
@@ -223,7 +186,7 @@ def app(tmp_path):
     os.environ['FLASK_SQLALCHEMY_DATABASE_URI'] = new_db_uri
 
     logging.info("Creating Flask app for testing, time = %s", datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
-
+    from yaptide.persistence.database import db
     app = create_app()
     with app.app_context():
         db.drop_all()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,26 +11,6 @@ from yaptide.admin.simulator_storage import download_shieldhit_from_s3_or_from_w
 from yaptide.application import create_app
 
 
-@pytest.fixture(scope="function")
-def celery_worker_parameters() -> Generator[dict, None, None]:
-    """
-    Default celery worker parameters cause problems with finding "ping task" module, as being described here:
-    https://github.com/celery/celery/issues/4851#issuecomment-604073785
-    To solve that issue we disable the ping check.
-    Another solution would be to do `from celery.contrib.testing.tasks import ping` but current one is more elegant.
-    Here we could as well configure other fixture worker parameters, like app, pool, loglevel, etc.
-    """
-    logging.info("Creating celery worker parameters for testing")
-
-    # get current logging level
-    log_level = logging.getLogger().getEffectiveLevel()
-
-    yield {
-        "concurrency": 2,
-        "loglevel": log_level,  # set celery worker log level to the same as the one used by pytest
-    }
-
-
 @pytest.fixture(scope='session')
 def small_simulation_payload(payload_editor_dict_data: dict) -> Generator[dict, None, None]:
     """Small simulation payload for testing purposes"""
@@ -137,6 +117,22 @@ def add_simulator_mocks_to_path_variable(yaptide_fake_dir: Path):
 
     # Restore the original PATH
     os.environ['PATH'] = original_path
+
+
+@pytest.fixture(scope="function")
+def celery_worker_parameters() -> Generator[dict, None, None]:
+    """
+    Here we could as well configure other fixture worker parameters, like app, pool, loglevel, etc.
+    """
+    logging.info("Creating celery worker parameters for testing")
+
+    # get current logging level
+    log_level = logging.getLogger().getEffectiveLevel()
+
+    yield {
+        "concurrency": 2,
+        "loglevel": log_level,  # set celery worker log level to the same as the one used by pytest
+    }
 
 
 @pytest.fixture(scope='function')

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,11 +11,6 @@ from yaptide.admin.simulator_storage import download_shieldhit_from_s3_or_from_w
 from yaptide.application import create_app
 
 
-@pytest.fixture(scope='session')
-def celery_enable_logging():
-    return True
-
-
 @pytest.fixture(scope="function")
 def celery_worker_parameters() -> Generator[dict, None, None]:
     """

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -121,9 +121,7 @@ def add_simulator_mocks_to_path_variable(yaptide_fake_dir: Path):
 
 @pytest.fixture(scope="function")
 def celery_worker_parameters() -> Generator[dict, None, None]:
-    """
-    Here we could as well configure other fixture worker parameters, like app, pool, loglevel, etc.
-    """
+    """Here we could as well configure other fixture worker parameters, like app, pool, loglevel, etc."""
     logging.info("Creating celery worker parameters for testing")
 
     # get current logging level

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,7 @@ from typing import Generator
 import pytest
 from yaptide.admin.simulator_storage import download_shieldhit_from_s3_or_from_website
 from yaptide.application import create_app
-from celery.contrib.pytest import *
+
 
 
 @pytest.fixture(scope='session')

--- a/tests/integration/test_celery.py
+++ b/tests/integration/test_celery.py
@@ -13,13 +13,14 @@ import platform
 import numpy as np
 import pytest  # skipcq: PY-W2000
 
-from celery import group, chord
-
 # note that the imports below will in turn call `from yaptide.celery.worker import celery_app`
 # that will create a `celery_app` instance
 from yaptide.celery.tasks import run_single_simulation, merge_results
 from yaptide.utils.sim_utils import files_dict_with_adjusted_primaries
-from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters,celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
+
+from celery import group, chord
+# skipcq: PYL-W0622
+from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
 
 
 @pytest.mark.usefixtures("live_server", "live_server_win")

--- a/tests/integration/test_celery.py
+++ b/tests/integration/test_celery.py
@@ -20,13 +20,13 @@ from yaptide.utils.sim_utils import files_dict_with_adjusted_primaries
 
 from celery import group, chord
 # skipcq: PY-W2000
-from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
+from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, use_celery_app_trap, celery_includes, celery_worker_pool
 
 
 @pytest.mark.usefixtures("live_server", "live_server_win")
 def test_celery_run_simulation_for_shieldhit(celery_app, celery_worker, payload_editor_dict_data: dict, client,
-                                             add_simulators_to_path_variable, modify_tmpdir,
-                                             shieldhit_binary_installed):
+                                             add_simulators_to_path_variable, modify_tmpdir, shieldhit_binary_installed,
+                                             celery_enable_logging):
     """Test run_simulation task with SHIELD-HIT12A binary
     Current Windows demo version version of SHIELD-HIT12A has a bug, so it cannot parse more elaborated input files.
     Parser relies on rewind function, which does not work properly on Windows, see:

--- a/tests/integration/test_celery.py
+++ b/tests/integration/test_celery.py
@@ -20,13 +20,13 @@ from yaptide.utils.sim_utils import files_dict_with_adjusted_primaries
 
 from celery import group, chord
 # skipcq: PY-W2000
-from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, use_celery_app_trap, celery_includes, celery_worker_pool
+from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_enable_logging, celery_parameters, use_celery_app_trap, celery_includes, celery_worker_pool
 
 
 @pytest.mark.usefixtures("live_server", "live_server_win")
 def test_celery_run_simulation_for_shieldhit(celery_app, celery_worker, payload_editor_dict_data: dict, client,
-                                             add_simulators_to_path_variable, modify_tmpdir, shieldhit_binary_installed,
-                                             celery_enable_logging):
+                                             add_simulators_to_path_variable, modify_tmpdir,
+                                             shieldhit_binary_installed):
     """Test run_simulation task with SHIELD-HIT12A binary
     Current Windows demo version version of SHIELD-HIT12A has a bug, so it cannot parse more elaborated input files.
     Parser relies on rewind function, which does not work properly on Windows, see:

--- a/tests/integration/test_celery.py
+++ b/tests/integration/test_celery.py
@@ -19,7 +19,7 @@ from yaptide.celery.tasks import run_single_simulation, merge_results
 from yaptide.utils.sim_utils import files_dict_with_adjusted_primaries
 
 from celery import group, chord
-# skipcq: PYL-W0622
+# skipcq: PY-W2000
 from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
 
 

--- a/tests/integration/test_celery.py
+++ b/tests/integration/test_celery.py
@@ -19,6 +19,7 @@ from celery import group, chord
 # that will create a `celery_app` instance
 from yaptide.celery.tasks import run_single_simulation, merge_results
 from yaptide.utils.sim_utils import files_dict_with_adjusted_primaries
+from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters,celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
 
 
 @pytest.mark.usefixtures("live_server", "live_server_win")

--- a/tests/integration/test_list_simulations.py
+++ b/tests/integration/test_list_simulations.py
@@ -7,7 +7,7 @@ from flask import Flask
 
 from yaptide.routes.user_routes import DEFAULT_PAGE_SIZE
 
-# skipcq: PYL-W0622
+# skipcq: PY-W2000
 from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
 
 

--- a/tests/integration/test_list_simulations.py
+++ b/tests/integration/test_list_simulations.py
@@ -8,12 +8,13 @@ from flask import Flask
 from yaptide.routes.user_routes import DEFAULT_PAGE_SIZE
 
 # skipcq: PY-W2000
-from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
+from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, use_celery_app_trap, celery_includes, celery_worker_pool
 
 
 @pytest.mark.usefixtures("live_server", "live_server_win")
 def test_list_simulations(celery_app, celery_worker, client: Flask, db_good_username: str, db_good_password: str,
-                          small_simulation_payload: dict, add_simulators_to_path_variable, shieldhit_binary_installed):
+                          small_simulation_payload: dict, add_simulators_to_path_variable, shieldhit_binary_installed,
+                          celery_enable_logging):
     """Test we can run simulations"""
     client.put("/auth/register",
                data=json.dumps(dict(username=db_good_username, password=db_good_password)),

--- a/tests/integration/test_list_simulations.py
+++ b/tests/integration/test_list_simulations.py
@@ -6,18 +6,14 @@ import pytest  # skipcq: PY-W2000
 from flask import Flask
 
 from yaptide.routes.user_routes import DEFAULT_PAGE_SIZE
-from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters,celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
+
+# skipcq: PYL-W0622
+from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
 
 
 @pytest.mark.usefixtures("live_server", "live_server_win")
-def test_list_simulations(celery_app,
-                          celery_worker,
-                          client: Flask,
-                          db_good_username: str,
-                          db_good_password: str,
-                          small_simulation_payload: dict,
-                          add_simulators_to_path_variable,
-                          shieldhit_binary_installed):
+def test_list_simulations(celery_app, celery_worker, client: Flask, db_good_username: str, db_good_password: str,
+                          small_simulation_payload: dict, add_simulators_to_path_variable, shieldhit_binary_installed):
     """Test we can run simulations"""
     client.put("/auth/register",
                data=json.dumps(dict(username=db_good_username, password=db_good_password)),
@@ -33,9 +29,7 @@ def test_list_simulations(celery_app,
     # by default we have 6 simulations per page, therefore we need to send 7 to test pagination
     number_of_simulations = 7
     for _ in range(number_of_simulations):
-        resp = client.post("/jobs/direct",
-                           data=json.dumps(small_simulation_payload),
-                           content_type='application/json')
+        resp = client.post("/jobs/direct", data=json.dumps(small_simulation_payload), content_type='application/json')
 
         assert resp.status_code == 202  # skipcq: BAN-B101
         data = json.loads(resp.data.decode())
@@ -73,7 +67,12 @@ def test_list_simulations(celery_app,
     # check first page with 3 items out of 7
     page_size = 3
     resp = client.get("/user/simulations",
-                      query_string={"page_size": page_size, "page_idx": 1, "order_by": "start_time", "order_type": "descend"})
+                      query_string={
+                          "page_size": page_size,
+                          "page_idx": 1,
+                          "order_by": "start_time",
+                          "order_type": "descend"
+                      })
     assert resp.status_code == 200  # skipcq: BAN-B101
     data = json.loads(resp.data.decode())
     logging.info("descending order, page 1")
@@ -88,7 +87,12 @@ def test_list_simulations(celery_app,
 
     # check second page with 1 item out of 7, not different ordering
     resp = client.get("/user/simulations",
-                      query_string={"page_size": page_size, "page_idx": 3, "order_by": "start_time", "order_type": "ascend"})
+                      query_string={
+                          "page_size": page_size,
+                          "page_idx": 3,
+                          "order_by": "start_time",
+                          "order_type": "ascend"
+                      })
     assert resp.status_code == 200  # skipcq: BAN-B101
     data = json.loads(resp.data.decode())
     logging.info("ascending order, page 3")

--- a/tests/integration/test_list_simulations.py
+++ b/tests/integration/test_list_simulations.py
@@ -8,13 +8,12 @@ from flask import Flask
 from yaptide.routes.user_routes import DEFAULT_PAGE_SIZE
 
 # skipcq: PY-W2000
-from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, use_celery_app_trap, celery_includes, celery_worker_pool
+from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_enable_logging, celery_parameters, use_celery_app_trap, celery_includes, celery_worker_pool
 
 
 @pytest.mark.usefixtures("live_server", "live_server_win")
 def test_list_simulations(celery_app, celery_worker, client: Flask, db_good_username: str, db_good_password: str,
-                          small_simulation_payload: dict, add_simulators_to_path_variable, shieldhit_binary_installed,
-                          celery_enable_logging):
+                          small_simulation_payload: dict, add_simulators_to_path_variable, shieldhit_binary_installed):
     """Test we can run simulations"""
     client.put("/auth/register",
                data=json.dumps(dict(username=db_good_username, password=db_good_password)),

--- a/tests/integration/test_list_simulations.py
+++ b/tests/integration/test_list_simulations.py
@@ -6,6 +6,7 @@ import pytest  # skipcq: PY-W2000
 from flask import Flask
 
 from yaptide.routes.user_routes import DEFAULT_PAGE_SIZE
+from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters,celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
 
 
 @pytest.mark.usefixtures("live_server", "live_server_win")

--- a/tests/integration/test_run_crashing_simulation.py
+++ b/tests/integration/test_run_crashing_simulation.py
@@ -5,7 +5,7 @@ import pytest  # skipcq: PY-W2000
 from time import sleep
 from flask import Flask
 
-# skipcq: PYL-W0622
+# skipcq: PY-W2000
 from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
 
 

--- a/tests/integration/test_run_crashing_simulation.py
+++ b/tests/integration/test_run_crashing_simulation.py
@@ -4,7 +4,7 @@ import logging
 import pytest  # skipcq: PY-W2000
 from time import sleep
 from flask import Flask
-
+from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters,celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
 
 @pytest.mark.usefixtures("live_server", "live_server_win")
 def test_run_simulation_with_flask_crashing(celery_app,

--- a/tests/integration/test_run_crashing_simulation.py
+++ b/tests/integration/test_run_crashing_simulation.py
@@ -4,18 +4,15 @@ import logging
 import pytest  # skipcq: PY-W2000
 from time import sleep
 from flask import Flask
-from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters,celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
+
+# skipcq: PYL-W0622
+from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
+
 
 @pytest.mark.usefixtures("live_server", "live_server_win")
-def test_run_simulation_with_flask_crashing(celery_app,
-                                            celery_worker,
-                                            client: Flask,
-                                            db_good_username: str,
-                                            db_good_password: str,
-                                            payload_files_dict_data: dict,
-                                            modify_tmpdir,
-                                            add_simulators_to_path_variable,
-                                            shieldhit_binary_installed):
+def test_run_simulation_with_flask_crashing(celery_app, celery_worker, client: Flask, db_good_username: str,
+                                            db_good_password: str, payload_files_dict_data: dict, modify_tmpdir,
+                                            add_simulators_to_path_variable, shieldhit_binary_installed):
     """Test we can run simulations"""
     client.put("/auth/register",
                data=json.dumps(dict(username=db_good_username, password=db_good_password)),
@@ -33,9 +30,7 @@ def test_run_simulation_with_flask_crashing(celery_app,
     payload_dict_with_broken_input["input_files"]["mat.dat"] = ""
 
     logging.info("Sending job submition request on /jobs/direct endpoint")
-    resp = client.post("/jobs/direct",
-                       data=json.dumps(payload_dict_with_broken_input),
-                       content_type='application/json')
+    resp = client.post("/jobs/direct", data=json.dumps(payload_dict_with_broken_input), content_type='application/json')
 
     assert resp.status_code == 202  # skipcq: BAN-B101
     data = json.loads(resp.data.decode())
@@ -50,14 +45,14 @@ def test_run_simulation_with_flask_crashing(celery_app,
     assert {"input_type", "input_files", "number_of_all_primaries"} == set(data["input"].keys())
     required_converted_files = {"beam.dat", "detect.dat", "geo.dat", "info.json", "mat.dat"}
     assert required_converted_files == required_converted_files.intersection(set(data["input"]["input_files"].keys()))
-    
+
     counter = 0
     wait_this_long = 30
     while True:
         if counter > wait_this_long:
             logging.error("Job did not crash in %d seconds - aborting", wait_this_long)
             assert False
-        counter+=1
+        counter += 1
         logging.debug("Sending check job status request on /jobs endpoint, attempt %d", counter)
         resp = client.get("/jobs", query_string={"job_id": job_id})
         assert resp.status_code == 200  # skipcq: BAN-B101

--- a/tests/integration/test_run_crashing_simulation.py
+++ b/tests/integration/test_run_crashing_simulation.py
@@ -6,14 +6,13 @@ from time import sleep
 from flask import Flask
 
 # skipcq: PY-W2000
-from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, use_celery_app_trap, celery_includes, celery_worker_pool
+from celery.contrib.pytest import celery_app, celery_worker, celery_enable_logging, celery_config, celery_parameters, use_celery_app_trap, celery_includes, celery_worker_pool
 
 
 @pytest.mark.usefixtures("live_server", "live_server_win")
 def test_run_simulation_with_flask_crashing(celery_app, celery_worker, client: Flask, db_good_username: str,
                                             db_good_password: str, payload_files_dict_data: dict, modify_tmpdir,
-                                            add_simulators_to_path_variable, shieldhit_binary_installed,
-                                            celery_enable_logging):
+                                            add_simulators_to_path_variable, shieldhit_binary_installed):
     """Test we can run simulations"""
     client.put("/auth/register",
                data=json.dumps(dict(username=db_good_username, password=db_good_password)),

--- a/tests/integration/test_run_crashing_simulation.py
+++ b/tests/integration/test_run_crashing_simulation.py
@@ -6,13 +6,14 @@ from time import sleep
 from flask import Flask
 
 # skipcq: PY-W2000
-from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
+from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, use_celery_app_trap, celery_includes, celery_worker_pool
 
 
 @pytest.mark.usefixtures("live_server", "live_server_win")
 def test_run_simulation_with_flask_crashing(celery_app, celery_worker, client: Flask, db_good_username: str,
                                             db_good_password: str, payload_files_dict_data: dict, modify_tmpdir,
-                                            add_simulators_to_path_variable, shieldhit_binary_installed):
+                                            add_simulators_to_path_variable, shieldhit_binary_installed,
+                                            celery_enable_logging):
     """Test we can run simulations"""
     client.put("/auth/register",
                data=json.dumps(dict(username=db_good_username, password=db_good_password)),

--- a/tests/integration/test_run_simulation.py
+++ b/tests/integration/test_run_simulation.py
@@ -5,7 +5,7 @@ import pytest  # skipcq: PY-W2000
 from time import sleep
 from flask import Flask
 
-# skipcq: PYL-W0622
+# skipcq: PY-W2000
 from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
 
 

--- a/tests/integration/test_run_simulation.py
+++ b/tests/integration/test_run_simulation.py
@@ -4,6 +4,7 @@ import logging
 import pytest  # skipcq: PY-W2000
 from time import sleep
 from flask import Flask
+from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters,celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
 
 
 @pytest.mark.usefixtures("live_server", "live_server_win")

--- a/tests/integration/test_run_simulation.py
+++ b/tests/integration/test_run_simulation.py
@@ -4,18 +4,15 @@ import logging
 import pytest  # skipcq: PY-W2000
 from time import sleep
 from flask import Flask
-from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters,celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
+
+# skipcq: PYL-W0622
+from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
 
 
 @pytest.mark.usefixtures("live_server", "live_server_win")
-def test_run_simulation_with_flask(celery_app,
-                                   celery_worker,
-                                   client: Flask,
-                                   db_good_username: str,
-                                   db_good_password: str,
-                                   small_simulation_payload: dict,
-                                   add_simulators_to_path_variable,
-                                   shieldhit_binary_installed):
+def test_run_simulation_with_flask(celery_app, celery_worker, client: Flask, db_good_username: str,
+                                   db_good_password: str, small_simulation_payload: dict,
+                                   add_simulators_to_path_variable, shieldhit_binary_installed):
     """Test we can run simulations"""
     client.put("/auth/register",
                data=json.dumps(dict(username=db_good_username, password=db_good_password)),
@@ -28,9 +25,7 @@ def test_run_simulation_with_flask(celery_app,
     assert resp.headers['Set-Cookie']  # skipcq: BAN-B101
 
     logging.info("Sending job submition request on /jobs/direct endpoint")
-    resp = client.post("/jobs/direct",
-                       data=json.dumps(small_simulation_payload),
-                       content_type='application/json')
+    resp = client.post("/jobs/direct", data=json.dumps(small_simulation_payload), content_type='application/json')
 
     assert resp.status_code == 202  # skipcq: BAN-B101
     jobs_direct_data = json.loads(resp.data.decode())
@@ -51,15 +46,15 @@ def test_run_simulation_with_flask(celery_app,
     assert {"message", "input"} == set(inputs_data.keys())
     assert {"input_type", "input_files", "input_json", "number_of_all_primaries"} == set(inputs_data["input"].keys())
     required_converted_files = {"beam.dat", "detect.dat", "geo.dat", "info.json", "mat.dat"}
-    assert required_converted_files == required_converted_files.intersection(set(inputs_data["input"]["input_files"].keys()))
+    assert required_converted_files == required_converted_files.intersection(
+        set(inputs_data["input"]["input_files"].keys()))
     requested_primaries = small_simulation_payload["input_json"]["beam"]["numberOfParticles"]
     requested_primaries /= small_simulation_payload["ntasks"]
 
     max_number_of_attempts = 200
     for i in range(max_number_of_attempts):
         logging.info("Sending check job status request on /jobs endpoint, attempt %d", i)
-        resp = client.get("/jobs",
-                          query_string={"job_id": job_id})
+        resp = client.get("/jobs", query_string={"job_id": job_id})
         assert resp.status_code == 200  # skipcq: BAN-B101
         jobs_data = json.loads(resp.data.decode())
 
@@ -71,7 +66,8 @@ def test_run_simulation_with_flask(celery_app,
         if jobs_data["job_state"] == 'RUNNING':
             # when job is is running, at least one task should be running
             # its interesting that it may happen that a job is RUNNING and still all tasks may be COMPLETED
-            assert any(task["task_state"] in {"RUNNING", "PENDING", "COMPLETED"} for task in jobs_data["job_tasks_status"])
+            assert any(task["task_state"] in {"RUNNING", "PENDING", "COMPLETED"}
+                       for task in jobs_data["job_tasks_status"])
 
             # check if during execution we have non-empty start_time  and empty end_time
             resp = client.get("/user/simulations")
@@ -91,8 +87,10 @@ def test_run_simulation_with_flask(celery_app,
                 logging.info("Expecting simulated_primaries: %s", requested_primaries)
                 logging.info("Got requested_primaries: %s", task["requested_primaries"])
                 logging.info("Got simulated_primaries: %s", task["simulated_primaries"])
-                assert task["requested_primaries"] == requested_primaries, f"Requested primaries should be equal to {requested_primaries}"
-                assert task["simulated_primaries"] == requested_primaries, f"Simulated primaries should be equal to {requested_primaries}"
+                assert task[
+                    "requested_primaries"] == requested_primaries, f"Requested primaries should be equal to {requested_primaries}"
+                assert task[
+                    "simulated_primaries"] == requested_primaries, f"Simulated primaries should be equal to {requested_primaries}"
         if jobs_data['job_state'] in ['COMPLETED', 'FAILED']:
             assert jobs_data['job_state'] == 'COMPLETED'
             logging.info("Job completed, exiting loop")

--- a/tests/integration/test_run_simulation.py
+++ b/tests/integration/test_run_simulation.py
@@ -6,13 +6,13 @@ from time import sleep
 from flask import Flask
 
 # skipcq: PY-W2000
-from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, use_celery_app_trap, celery_includes, celery_worker_pool
+from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_enable_logging, celery_parameters, use_celery_app_trap, celery_includes, celery_worker_pool
 
 
 @pytest.mark.usefixtures("live_server", "live_server_win")
 def test_run_simulation_with_flask(celery_app, celery_worker, client: Flask, db_good_username: str,
                                    db_good_password: str, small_simulation_payload: dict,
-                                   add_simulators_to_path_variable, shieldhit_binary_installed, celery_enable_logging):
+                                   add_simulators_to_path_variable, shieldhit_binary_installed):
     """Test we can run simulations"""
     client.put("/auth/register",
                data=json.dumps(dict(username=db_good_username, password=db_good_password)),

--- a/tests/integration/test_run_simulation.py
+++ b/tests/integration/test_run_simulation.py
@@ -6,13 +6,13 @@ from time import sleep
 from flask import Flask
 
 # skipcq: PY-W2000
-from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, celery_enable_logging, use_celery_app_trap, celery_includes, celery_worker_pool, celery_worker_parameters
+from celery.contrib.pytest import celery_app, celery_worker, celery_config, celery_parameters, use_celery_app_trap, celery_includes, celery_worker_pool
 
 
 @pytest.mark.usefixtures("live_server", "live_server_win")
 def test_run_simulation_with_flask(celery_app, celery_worker, client: Flask, db_good_username: str,
                                    db_good_password: str, small_simulation_payload: dict,
-                                   add_simulators_to_path_variable, shieldhit_binary_installed):
+                                   add_simulators_to_path_variable, shieldhit_binary_installed, celery_enable_logging):
     """Test we can run simulations"""
     client.put("/auth/register",
                data=json.dumps(dict(username=db_good_username, password=db_good_password)),


### PR DESCRIPTION
pytest-celery caused some probblems during running all integrations tests at once. Celery comes with it's own fixtures like celery_app, celery_worker that are sufficient for testing.