### PR TITLE
restart containers on reboot

### DIFF
--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -19,4 +19,9 @@ RUN rm /etc/nginx/conf.d/default.conf
 # Copy SSL certificate from the build stage
 COPY --from=cert-gen /certs /etc/nginx/conf.d
 
+# Copy the Nginx configuration
+COPY nginx.conf /etc/nginx/conf.d
+
+EXPOSE 5000
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -16,13 +16,7 @@ FROM nginx:1.25-alpine
 # Configure Nginx to serve as the proxy
 RUN rm /etc/nginx/conf.d/default.conf
 
-
 # Copy SSL certificate from the build stage
 COPY --from=cert-gen /certs /etc/nginx/conf.d
-
-# Copy the Nginx configuration
-COPY nginx.conf /etc/nginx/conf.d
-
-EXPOSE 5000
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -2,6 +2,7 @@ services:
   pgadmin:
     image: dpage/pgadmin4:latest
     container_name: yaptide_pgadmin4
+    restart: always
     environment:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-admin@example.com}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -2,7 +2,7 @@ services:
   pgadmin:
     image: dpage/pgadmin4:latest
     container_name: yaptide_pgadmin4
-    restart: always
+    restart: unless-stopped
     environment:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-admin@example.com}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,14 @@ services:
   redis:
     image: redis:7-alpine
     container_name: yaptide_redis
+    restart: always
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
 
   postgresql:
     image: postgres:16-alpine
     container_name: yaptide_postgresql
+    restart: always
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-yaptide_db}
       POSTGRES_USER: ${POSTGRES_USER:-yaptide_user}
@@ -28,6 +30,7 @@ services:
       dockerfile: Dockerfile-flask
     image: yaptide_flask
     container_name: yaptide_flask
+    restart: always
     environment:
       - CELERY_BROKER_URL=redis://yaptide_redis:6379/0
       - CELERY_RESULT_BACKEND=redis://yaptide_redis:6379/0
@@ -48,6 +51,7 @@ services:
       dockerfile: Dockerfile-worker
     image: yaptide_worker
     container_name: yaptide_worker
+    restart: always
     volumes:
       - simulators:/simulators:rw
     deploy:
@@ -72,6 +76,7 @@ services:
   nginx:
     image: yaptide_nginx
     container_name: yaptide_nginx
+    restart: always
     build:
       context: .
       dockerfile: Dockerfile-nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,14 @@ services:
   redis:
     image: redis:7-alpine
     container_name: yaptide_redis
-    restart: always
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
 
   postgresql:
     image: postgres:16-alpine
     container_name: yaptide_postgresql
-    restart: always
+    restart: unless-stopped
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-yaptide_db}
       POSTGRES_USER: ${POSTGRES_USER:-yaptide_user}
@@ -30,7 +30,7 @@ services:
       dockerfile: Dockerfile-flask
     image: yaptide_flask
     container_name: yaptide_flask
-    restart: always
+    restart: unless-stopped
     environment:
       - CELERY_BROKER_URL=redis://yaptide_redis:6379/0
       - CELERY_RESULT_BACKEND=redis://yaptide_redis:6379/0
@@ -51,7 +51,7 @@ services:
       dockerfile: Dockerfile-worker
     image: yaptide_worker
     container_name: yaptide_worker
-    restart: always
+    restart: unless-stopped
     volumes:
       - simulators:/simulators:rw
     deploy:
@@ -76,7 +76,7 @@ services:
   nginx:
     image: yaptide_nginx
     container_name: yaptide_nginx
-    restart: always
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile-nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,8 +83,6 @@ services:
     ports:
       - 5000:5000
       - 8443:8443
-    volumes:
-      - ./nginx.conf:/etc/nginx/conf.d/nginx.conf:ro
     depends_on:
       yaptide_flask:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,8 @@ services:
     ports:
       - 5000:5000
       - 8443:8443
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/nginx.conf:ro
     depends_on:
       yaptide_flask:
         condition: service_healthy


### PR DESCRIPTION
I've noticed that on yap-dev and on production every time I restarted host instance, I had to bring back to life yaptide containers. With the changes here they should restart automatically after reboot