### PR TITLE
Fix code scanning alert no. 4: Reflected server-side cross-site scripting

### DIFF
--- a/yaptide/routes/utils/response_templates.py
+++ b/yaptide/routes/utils/response_templates.py
@@ -1,5 +1,7 @@
 from flask import Response, make_response
 import html
+
+
 def yaptide_response(message: str, code: int, content: dict = None) -> Response:
     """Function returning Response object"""
     response_dict = {'message': html.escape(message)}

--- a/yaptide/routes/utils/response_templates.py
+++ b/yaptide/routes/utils/response_templates.py
@@ -1,9 +1,9 @@
 from flask import Response, make_response
-
+import html
 
 def yaptide_response(message: str, code: int, content: dict = None) -> Response:
     """Function returning Response object"""
-    response_dict = {'message': message}
+    response_dict = {'message': html.escape(message)}
     if content:
         response_dict.update(content)
     return make_response(response_dict, code)

--- a/yaptide/routes/utils/response_templates.py
+++ b/yaptide/routes/utils/response_templates.py
@@ -1,6 +1,5 @@
 from flask import Response, make_response
 import html
-
 def yaptide_response(message: str, code: int, content: dict = None) -> Response:
     """Function returning Response object"""
     response_dict = {'message': html.escape(message)}


### PR DESCRIPTION
Fixes [https://github.com/yaptide/yaptide/security/code-scanning/4](https://github.com/yaptide/yaptide/security/code-scanning/4)

To fix the problem, we need to ensure that any user-provided input included in the response is properly escaped to prevent XSS attacks. In this case, we can use the `html.escape` function from Python's standard library to escape the `message` parameter before including it in the `response_dict`.

- Modify the `yaptide_response` function in `yaptide/routes/utils/response_templates.py` to escape the `message` parameter.
- Import the `html` module to use the `html.escape` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
