### PR TITLE
improved SH12A demo exe download

### DIFF
--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Get simulators for Linux
         if: matrix.platform == 'ubuntu-latest'
         run: |
-            poetry run python yaptide/admin/simulators.py download-shieldhit --decrypt --dir bin/
+            blah blah poetry run python yaptide/admin/simulators.py download-shieldhit --decrypt --dir bin/
         timeout-minutes: 2
         env:
           S3_ENDPOINT: ${{ vars.S3_ENDPOINT }}

--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -39,7 +39,7 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
         id: get_simulators
         run: |
-            blah blah poetry run python yaptide/admin/simulators.py download-shieldhit --decrypt --dir bin/
+            poetry run python yaptide/admin/simulators.py download-shieldhit --decrypt --dir bin/
         timeout-minutes: 2
         env:
           S3_ENDPOINT: ${{ vars.S3_ENDPOINT }}

--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -52,14 +52,15 @@ jobs:
   
       # fallback to demo version of SHIELD-HIT12A
       - name: Get demo simulators for Linux due to timeout
-        if: matrix.platform == 'ubuntu-latest' && always()
+        if: matrix.platform == 'ubuntu-latest'
         run: |
-          if [[ ${{ job.status }} == 'failure' ]]; then
+          echo "Job status is: ${{ job.status }}"
+          if [[ "${{ job.status }}" == "failure" ]]; then
             echo "Retrying due to timeout..."
             poetry run python yaptide/admin/simulators.py download-shieldhit --dir bin/
           fi
-        timeout-minutes: 2
-  
+        timeout-minutes: 1
+    
       - name: Get demo simulator for Windows
         if: matrix.platform == 'windows-latest'
         run: |

--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -37,6 +37,7 @@ jobs:
       # try downloading full version of SHIELD-HIT12A
       - name: Get simulators for Linux
         if: matrix.platform == 'ubuntu-latest'
+        id: get_simulators
         run: |
             blah blah poetry run python yaptide/admin/simulators.py download-shieldhit --decrypt --dir bin/
         timeout-minutes: 2
@@ -49,17 +50,15 @@ jobs:
           S3_SHIELDHIT_BUCKET: ${{ vars.S3_LINUX_SHIELDHIT_BUCKET }}
           S3_SHIELDHIT_KEY: ${{ vars.S3_LINUX_SHIELDHIT_KEY }}
         continue-on-error: true
-  
+
       # fallback to demo version of SHIELD-HIT12A
       - name: Get demo simulators for Linux due to timeout
-        if: matrix.platform == 'ubuntu-latest'
+        if: matrix.platform == 'ubuntu-latest' && steps.get_simulators.outcome == 'failure'
         run: |
-          echo "Job status is: ${{ job.status }}"
-          if [[ "${{ job.status }}" == "failure" ]]; then
-            echo "Retrying due to timeout..."
-            poetry run python yaptide/admin/simulators.py download-shieldhit --dir bin/
-          fi
+          echo "Retrying due to timeout..."
+          poetry run python yaptide/admin/simulators.py download-shieldhit --dir bin/
         timeout-minutes: 1
+
     
       - name: Get demo simulator for Windows
         if: matrix.platform == 'windows-latest'


### PR DESCRIPTION
Previously, detection of the step failure with `if [[ ${{ job.status }} == 'failure' ]]; then` was broken, this is a version which seems to work. Even if download via S3 failed, the "demo download" step was never activated. In case of S3 download failure, the `job.status` was always "success". Below AI generated summary of the PR:

![image](https://github.com/user-attachments/assets/904feabb-5d77-45ff-b91e-935a28683cfb)


This pull request includes updates to the `.github/workflows/test-run.yml` file to improve the logic for handling simulator downloads on Ubuntu.

Changes to workflow logic:

* Added an `id` to the "Get simulators for Linux" step to track its outcome for conditional execution.
* Modified the condition for the "Get demo simulators for Linux due to timeout" step to check the outcome of the previous step instead of always running on failure.