### PR TITLE
Remove convert endpoint, not being used by UI now

### DIFF
--- a/yaptide/routes/celery_routes.py
+++ b/yaptide/routes/celery_routes.py
@@ -8,7 +8,6 @@ from marshmallow import Schema, fields
 from uuid import uuid4
 
 from yaptide.celery.simulation_worker import celery_app
-from yaptide.celery.tasks import convert_input_files
 from yaptide.celery.utils.manage_tasks import (get_job_results, run_job)
 from yaptide.persistence.db_methods import (add_object_to_db, fetch_celery_simulation_by_job_id,
                                             fetch_celery_tasks_by_sim_id, fetch_estimators_by_sim_id,
@@ -237,21 +236,3 @@ class ResultsDirect(Resource):
 
         logging.debug("Returning results from Celery")
         return yaptide_response(message=f"Results for job: {job_id}, results from Celery", code=200, content=result)
-
-
-class ConvertResource(Resource):
-    """Class responsible for returning input_model files converted from front JSON"""
-
-    @staticmethod
-    @requires_auth()
-    def post(_: UserModel):
-        """Method handling input_model files convertion"""
-        payload_dict: dict = request.get_json(force=True)
-        if not payload_dict:
-            return yaptide_response(message="No JSON in body", code=400)
-
-        # Rework in later PRs to match pattern from jobs endpoint
-        job = convert_input_files.delay(payload_dict=payload_dict)
-        result: dict = job.wait()
-
-        return yaptide_response(message="Converted Input Files", code=200, content=result)

--- a/yaptide/routes/main_routes.py
+++ b/yaptide/routes/main_routes.py
@@ -2,7 +2,7 @@ from flask_restful import Api, Resource
 
 from yaptide.routes.auth_routes import (AuthLogIn, AuthLogOut, AuthRefresh, AuthRegister, AuthStatus)
 from yaptide.routes.batch_routes import Clusters, JobsBatch
-from yaptide.routes.celery_routes import ConvertResource, JobsDirect
+from yaptide.routes.celery_routes import JobsDirect
 from yaptide.routes.common_sim_routes import (JobsResource, InputsResource, LogfilesResource, ResultsResource)
 from yaptide.routes.estimator_routes import EstimatorResource
 from yaptide.routes.keycloak_routes import AuthKeycloak
@@ -34,8 +34,6 @@ def initialize_routes(api: Api):
     api.add_resource(ResultsResource, "/results")
     api.add_resource(InputsResource, "/inputs")
     api.add_resource(LogfilesResource, "/logfiles")
-
-    api.add_resource(ConvertResource, "/convert")
 
     api.add_resource(UserSimulations, "/user/simulations")
     api.add_resource(UserUpdate, "/user/update")


### PR DESCRIPTION
Fixes #1237

Remove the `ConvertResource` class and its associated `/convert` endpoint from the `celery_routes.py` file.

Remove the `ConvertResource` import statement and its associated `/convert` endpoint from the `main_routes.py` file.

UI handles conversion by pyodide if needed on UI side, otherwise backend converts the JSON into input files internally. There is no need to expose this feature as the endpoint.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yaptide/yaptide/pull/1269?shareId=2c1158c4-8e46-4c6f-aab6-b091fc7c9d51).