### PR TITLE
fix bug in string templates

### DIFF
--- a/yaptide/batch/batch_methods.py
+++ b/yaptide/batch/batch_methods.py
@@ -251,7 +251,7 @@ def prepare_script_files(payload_dict: dict, job_dir: str, sim_id: int, update_k
                                          backend_url=backend_url)
     collect_script = collect_template.format(collect_header=collect_header,
                                              root_dir=job_dir,
-                                             clear_forts="true",
+                                             remove_output_from_workspace="true",
                                              sim_id=sim_id,
                                              update_key=update_key,
                                              backend_url=backend_url)

--- a/yaptide/batch/fluka_string_templates.py
+++ b/yaptide/batch/fluka_string_templates.py
@@ -7,7 +7,6 @@ cd $ROOT_DIR
 mkdir -p $ROOT_DIR/workspaces/task_{{0001..{n_tasks}}}
 mkdir -p $ROOT_DIR/input
 
-
 INPUT_DIR=$ROOT_DIR/input
 ARRAY_SCRIPT=$ROOT_DIR/array_script.sh
 COLLECT_SCRIPT=$ROOT_DIR/collect_script.sh
@@ -53,6 +52,9 @@ fi
 
 python3 $ROOT_DIR/simulation_data_sender.py --output_dir=$OUTPUT_DIRECTORY \\
     --sim_id={sim_id} --update_key={update_key} --backend_url={backend_url}
+
+python3 $ROOT_DIR/simulation_data_sender.py --sim_id={sim_id} --update_key={update_key} \\
+      --backend_url={backend_url} --simulation_state=COMPLETED
 """
 
 ARRAY_FLUKA_BASH: str = """#!/bin/bash

--- a/yaptide/batch/fluka_string_templates.py
+++ b/yaptide/batch/fluka_string_templates.py
@@ -45,7 +45,7 @@ python3 $ROOT_DIR/simulation_data_sender.py --sim_id={sim_id} --update_key={upda
 module load pymchelper
 convertmc json --many "$INPUT_WILDCARD"
 
-CLEAR_FORTS={clear_forts}
+CLEAR_FORTS={remove_output_from_workspace}
 
 if $CLEAR_FORTS; then
     rm $INPUT_WILDCARD
@@ -83,14 +83,14 @@ sig_handler()
     wait # wait for all children, this is important!
 }}
 
-FILE_TO_WATCH=$WORK_DIR/fluka_`printf %04d $SLURM_ARRAY_TASK_ID`.log
-python3 $ROOT_DIR/watcher.py \
-    --filepath=$FILE_TO_WATCH\
-    --sim_id={sim_id}\
-    --task_id=$SLURM_ARRAY_TASK_ID\
-    --update_key={update_key}\
-    --backend_url={backend_url}\
-    --verbose 1>watcher_$SLURM_ARRAY_TASK_ID.stdout 2>watcher_$SLURM_ARRAY_TASK_ID.stderr &
+# FILE_TO_WATCH=$WORK_DIR/fluka_`printf %04d $SLURM_ARRAY_TASK_ID`.log
+# python3 $ROOT_DIR/watcher.py \
+#     --filepath=$FILE_TO_WATCH\
+#     --sim_id={sim_id}\
+#     --task_id=$SLURM_ARRAY_TASK_ID\
+#     --update_key={update_key}\
+#     --backend_url={backend_url}\
+#     --verbose 1>watcher_$SLURM_ARRAY_TASK_ID.stdout 2>watcher_$SLURM_ARRAY_TASK_ID.stderr &
 
 trap 'sig_handler' SIGUSR1
 

--- a/yaptide/batch/shieldhit_string_templates.py
+++ b/yaptide/batch/shieldhit_string_templates.py
@@ -43,7 +43,7 @@ cd $OUTPUT_DIRECTORY
 
 convertmc json --many "$INPUT_WILDCARD"
 
-CLEAR_BDOS={clear_bdos}
+CLEAR_BDOS={remove_output_from_workspace}
 
 if $CLEAR_BDOS; then
     rm $INPUT_WILDCARD


### PR DESCRIPTION
This pull request includes several changes to the batch processing scripts in the `yaptide` project to improve the handling of output files and streamline the workflow. The most important changes include renaming a variable for clarity, updating script templates, and removing an unnecessary script execution.

Variable renaming and script updates:

* [`yaptide/batch/batch_methods.py`](diffhunk://#diff-8ebdca43a699e4c2f00504e7c714e4ef6ee3056fc0375630388e4c5791dc90f5L254-R254): Renamed the `clear_forts` variable to `remove_output_from_workspace` to better reflect its purpose.
* [`yaptide/batch/fluka_string_templates.py`](diffhunk://#diff-bfad28ac61fbfcfe8e996f0ac9699fa92a81775e5691d781fb51316d3e64fb28L48-R57): Updated the script templates to use the new `remove_output_from_workspace` variable name. [[1]](diffhunk://#diff-bfad28ac61fbfcfe8e996f0ac9699fa92a81775e5691d781fb51316d3e64fb28L48-R57) [[2]](diffhunk://#diff-f86ad84a083f5785ee9dc3c8d2a9b0a57a54c95d62084467977c41db9e75ef86L46-R46)

Script execution removal:

* [`yaptide/batch/fluka_string_templates.py`](diffhunk://#diff-bfad28ac61fbfcfe8e996f0ac9699fa92a81775e5691d781fb51316d3e64fb28L86-R95): Removed the execution of the `watcher.py` script, which is no longer necessary.

Minor formatting changes:

* [`yaptide/batch/fluka_string_templates.py`](diffhunk://#diff-bfad28ac61fbfcfe8e996f0ac9699fa92a81775e5691d781fb51316d3e64fb28L10): Removed an extra newline for consistency.