### PR TITLE
Progress bar behaviour fix

### DIFF
--- a/yaptide/persistence/models.py
+++ b/yaptide/persistence/models.py
@@ -249,6 +249,7 @@ class TaskModel(db.Model):
             "requested_primaries": self.requested_primaries,
             "simulated_primaries": self.simulated_primaries,
             "last_update_time": self.last_update_time,
+            "task_id": self.id
         }
         if self.estimated_time:
             result["estimated_time"] = {

--- a/yaptide/routes/common_sim_routes.py
+++ b/yaptide/routes/common_sim_routes.py
@@ -54,6 +54,7 @@ class JobsResource(Resource):
         tasks = fetch_tasks_by_sim_id(sim_id=simulation.id)
 
         job_tasks_status = [task.get_status_dict() for task in tasks]
+        job_tasks_status = sorted(job_tasks_status, key=lambda x: x["task_id"])
 
         if simulation.job_state in (EntityState.COMPLETED.value, EntityState.FAILED.value,
                                     EntityState.MERGING_QUEUED.value, EntityState.MERGING_RUNNING.value):


### PR DESCRIPTION
This pull request introduces enhancements to the task status handling and retrieval logic. The changes ensure that task status dictionaries now include a `task_id` field and that task statuses are consistently sorted by `task_id` when fetched.

### Enhancements to task status handling:

* [`yaptide/persistence/models.py`](diffhunk://#diff-4b8473e45fecb31924a9768d0ea11ecd57ea27d99f39689517035d22a9c2689eR252): Updated the `get_status_dict` method to include the `task_id` field in the returned dictionary, providing a unique identifier for each task.

* [`yaptide/routes/common_sim_routes.py`](diffhunk://#diff-40ee953c21b980818ac611a5e33f1dbe7220a3d9bae1341b2556feb8fa1ee157R57): Modified the `get` function to sort the list of task status dictionaries by `task_id`, ensuring consistent ordering when tasks are retrieved.