### PR TITLE
configured ruff to work with the tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,28 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
-    -   id: check-toml
-    -   id: check-added-large-files
--   repo: https://github.com/google/yapf
-    rev: v0.40.1
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.7
     hooks:
-    -   id: yapf
--   repo: local
+      - id: ruff
+        name: ruff check
+        args: [ --fix ]
+      - id: ruff-format
+        name: ruff format
+  - repo: local
     hooks:
-    -   id: check_not_empty_env_files
+      - id: check_not_empty_env_files
         name: Check not empty env files
         language: python
         entry: python3 .pre_commit_hooks/check_not_empty_files.py
-        types: [dotenv]
-        stages: [commit, push, manual]
+        types: [ dotenv ]
+        stages: [ commit, push, manual ]
 exclude: migrations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,8 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 # Tooling configuration
-[tool.yapf]
-based_on_style = "pep8"
-column_limit = 120
+[tool.ruff]
+line-length = 120
 
-[tool.yapfignore]
-ignore_patterns = [
-  ".venv/**"
-]
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["F401", "F811"]


### PR DESCRIPTION
This pull request updates the project's Python formatting and linting tools by replacing `yapf` with `ruff`, and updates the relevant configuration files accordingly. The changes streamline code formatting and linting under a single tool, and set up automatic fixing and per-file linting rules.

Tooling updates:

* Replaced the `yapf` pre-commit hook with two new hooks for `ruff` (`ruff check` with `--fix` and `ruff format`) in `.pre-commit-config.yaml`, switching from Google's formatter to the Ruff linter/formatter.
* Removed the `[tool.yapf]` and `[tool.yapfignore]` sections from `pyproject.toml` and added `[tool.ruff]` configuration, setting the line length and specifying per-file ignores for tests.